### PR TITLE
`Unlock All Suits` will no longer be displayed when all suits are unlocked

### DIFF
--- a/ProjectApparatus/GameObjectManager.cs
+++ b/ProjectApparatus/GameObjectManager.cs
@@ -108,23 +108,17 @@ public class GameObjectManager
 
 public enum UnlockableUpgrade : int
 {
-    OrangeSuit = 0,
     GreenSuit = 1,
     HazardSuit = 2,
     PajamaSuit = 3,
     CozyLights = 4,
     Teleporter = 5,
     Television = 6,
-    Cupboard = 7,
-    FileCabinet = 8,
     Toilet = 9,
     Shower = 10,
-    LightSwitch = 11,
     RecordPlayer = 12,
     Table = 13,
     RomanticTable = 14,
-    Bunkbeds = 15,
-    Terminal = 16,
     SignalTranslator = 17,
     LoudHorn = 18,
     InverseTeleporter = 19,

--- a/ProjectApparatus/Hacks.cs
+++ b/ProjectApparatus/Hacks.cs
@@ -340,38 +340,8 @@ namespace ProjectApparatus
             {
                 UI.TabContents("Upgrades", UI.Tabs.Upgrades, () =>
                 {
-                    UI.Button("Unlock All Upgrades", "Unlocks all ship upgrades.", () =>
-                    {
-                        for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
-                        {
-                            if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer) continue;
-
-                            StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
-                            StartOfRound.Instance.SyncShipUnlockablesServerRpc();
-                        }
-                    });
-
+                    bool allUpgradesUnlocked = true;
                     bool allSuitsUnlocked = true;
-                    for (int i = 1; i <= 3; i++)
-                    {
-                        if (!StartOfRound.Instance.unlockablesList.unlockables[i]?.hasBeenUnlockedByPlayer ?? false)
-                        {
-                            allSuitsUnlocked = false;
-                            break;
-                        }
-                    }
-
-                    if (!allSuitsUnlocked)
-                    {
-                        UI.Button("Unlock All Suits", "Unlocks all suits.", () =>
-                        {
-                            for (int i = 1; i <= 3; i++)
-                            {
-                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
-                            }
-                        });
-                    }
-
 
                     for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
                     {
@@ -383,16 +353,71 @@ namespace ProjectApparatus
                             || i == (int)UnlockableUpgrade.Terminal)
                             continue;
 
-                        if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
-                            continue;
-
-                        string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName);
-
-                        UI.Button(unlockableName, $"Unlock {unlockableName}", () =>
+                        if (!StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
                         {
-                            StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
-                            StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                            allUpgradesUnlocked = false;
+                            break;
+                        }
+                    }
+
+                    for (int i = 1; i <= 3; i++)
+                    {
+                        if (!StartOfRound.Instance.unlockablesList.unlockables[i]?.hasBeenUnlockedByPlayer ?? false)
+                        {
+                            allSuitsUnlocked = false;
+                            break;
+                        }
+                    }
+
+                    if (allUpgradesUnlocked && allSuitsUnlocked)
+                    {
+                        GUILayout.Label("You've already unlocked all upgrades.");
+                    }
+                    else
+                    {
+                        UI.Button("Unlock All Upgrades", "Unlocks all ship upgrades.", () =>
+                        {
+                            for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
+                            {
+                                if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer) continue;
+
+                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
+                                StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                            }
                         });
+
+                        if (!allSuitsUnlocked)
+                        {
+                            UI.Button("Unlock All Suits", "Unlocks all suits.", () =>
+                            {
+                                for (int i = 1; i <= 3; i++)
+                                {
+                                    StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
+                                }
+                            });
+                        }
+
+                        for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
+                        {
+                            if (i == (int)UnlockableUpgrade.OrangeSuit
+                                || i == (int)UnlockableUpgrade.Cupboard
+                                || i == (int)UnlockableUpgrade.FileCabinet
+                                || i == (int)UnlockableUpgrade.LightSwitch
+                                || i == (int)UnlockableUpgrade.Bunkbeds
+                                || i == (int)UnlockableUpgrade.Terminal)
+                                continue;
+
+                            if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
+                                continue;
+
+                            string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName);
+
+                            UI.Button(unlockableName, $"Unlock {unlockableName}", () =>
+                            {
+                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
+                                StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                            });
+                        }
                     }
                 });
             }

--- a/ProjectApparatus/Hacks.cs
+++ b/ProjectApparatus/Hacks.cs
@@ -340,8 +340,6 @@ namespace ProjectApparatus
             {
                 UI.TabContents("Upgrades", UI.Tabs.Upgrades, () =>
                 {
-                    GUILayout.Label("Upgrades:");
-
                     UI.Button("Unlock All Upgrades", "Unlocks all ship upgrades.", () =>
                     {
                         for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)

--- a/ProjectApparatus/Hacks.cs
+++ b/ProjectApparatus/Hacks.cs
@@ -345,15 +345,8 @@ namespace ProjectApparatus
 
                     for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
                     {
-                        if (i == (int)UnlockableUpgrade.OrangeSuit
-                            || i == (int)UnlockableUpgrade.Cupboard
-                            || i == (int)UnlockableUpgrade.FileCabinet
-                            || i == (int)UnlockableUpgrade.LightSwitch
-                            || i == (int)UnlockableUpgrade.Bunkbeds
-                            || i == (int)UnlockableUpgrade.Terminal)
-                            continue;
-
-                        if (!StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
+                        if (Enum.IsDefined(typeof(UnlockableUpgrade), i) &&
+                            !StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
                         {
                             allUpgradesUnlocked = false;
                             break;
@@ -379,10 +372,12 @@ namespace ProjectApparatus
                         {
                             for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
                             {
-                                if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer) continue;
-
-                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
-                                StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                                if (Enum.IsDefined(typeof(UnlockableUpgrade), i) &&
+                                    !StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
+                                {
+                                    StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
+                                    StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                                }
                             }
                         });
 
@@ -399,24 +394,17 @@ namespace ProjectApparatus
 
                         for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
                         {
-                            if (i == (int)UnlockableUpgrade.OrangeSuit
-                                || i == (int)UnlockableUpgrade.Cupboard
-                                || i == (int)UnlockableUpgrade.FileCabinet
-                                || i == (int)UnlockableUpgrade.LightSwitch
-                                || i == (int)UnlockableUpgrade.Bunkbeds
-                                || i == (int)UnlockableUpgrade.Terminal)
-                                continue;
-
-                            if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
-                                continue;
-
-                            string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName);
-
-                            UI.Button(unlockableName, $"Unlock {unlockableName}", () =>
+                            if (Enum.IsDefined(typeof(UnlockableUpgrade), i) &&
+                                !StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
                             {
-                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
-                                StartOfRound.Instance.SyncShipUnlockablesServerRpc();
-                            });
+                                string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName);
+
+                                UI.Button(unlockableName, $"Unlock {unlockableName}", () =>
+                                {
+                                    StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
+                                    StartOfRound.Instance.SyncShipUnlockablesServerRpc();
+                                });
+                            }
                         }
                     }
                 });

--- a/ProjectApparatus/Hacks.cs
+++ b/ProjectApparatus/Hacks.cs
@@ -336,9 +336,12 @@ namespace ProjectApparatus
                 }
             });
 
-            if (StartOfRound.Instance && instance.shipTerminal){
+            if (StartOfRound.Instance && instance.shipTerminal)
+            {
                 UI.TabContents("Upgrades", UI.Tabs.Upgrades, () =>
                 {
+                    GUILayout.Label("Upgrades:");
+
                     UI.Button("Unlock All Upgrades", "Unlocks all ship upgrades.", () =>
                     {
                         for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
@@ -350,17 +353,27 @@ namespace ProjectApparatus
                         }
                     });
 
-                    UI.Button($"Unlock All Suits", "Unlocks all suits.", () =>
+                    bool allSuitsUnlocked = true;
+                    for (int i = 1; i <= 3; i++)
                     {
-                        if ((bool)StartOfRound.Instance)
+                        if (!StartOfRound.Instance.unlockablesList.unlockables[i]?.hasBeenUnlockedByPlayer ?? false)
+                        {
+                            allSuitsUnlocked = false;
+                            break;
+                        }
+                    }
+
+                    if (!allSuitsUnlocked)
+                    {
+                        UI.Button("Unlock All Suits", "Unlocks all suits.", () =>
                         {
                             for (int i = 1; i <= 3; i++)
                             {
-                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, FindObjectOfType<Terminal>().groupCredits);
+                                StartOfRound.Instance.BuyShipUnlockableServerRpc(i, instance.shipTerminal.groupCredits);
                             }
-                        }
+                        });
+                    }
 
-                    });
 
                     for (int i = 0; i < StartOfRound.Instance.unlockablesList.unlockables.Count; i++)
                     {
@@ -375,7 +388,7 @@ namespace ProjectApparatus
                         if (StartOfRound.Instance.unlockablesList.unlockables[i].hasBeenUnlockedByPlayer)
                             continue;
 
-                        string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName) ;
+                        string unlockableName = PAUtils.ConvertFirstLetterToUpperCase(StartOfRound.Instance.unlockablesList.unlockables[i].unlockableName);
 
                         UI.Button(unlockableName, $"Unlock {unlockableName}", () =>
                         {
@@ -385,6 +398,7 @@ namespace ProjectApparatus
                     }
                 });
             }
+
             UI.TabContents("Graphics", UI.Tabs.Graphics, () =>
             {
                 UI.Checkbox(ref settingsData.b_DisableFog, "Disable Fog", "Disables the fog effect.");

--- a/ProjectApparatus/Resources/Changelog.txt
+++ b/ProjectApparatus/Resources/Changelog.txt
@@ -1,4 +1,5 @@
 ﻿v1.1.4
+• [/] 'Unlock All Suits' will no longer be displayed when all suits are unlocked.
 • [/] Config system is now using Json
 • [/] Fixed default ship objects appearing in the Upgrades tab.
 • [/] Fixed already-unlocked Upgrades appearing in the Upgrades tab.

--- a/ProjectApparatus/Resources/Changelog.txt
+++ b/ProjectApparatus/Resources/Changelog.txt
@@ -1,4 +1,5 @@
 ﻿v1.1.4
+• [/] If all upgrades and suits are unlocked, display a message.
 • [/] 'Unlock All Suits' will no longer be displayed when all suits are unlocked.
 • [/] Config system is now using Json
 • [/] Fixed default ship objects appearing in the Upgrades tab.


### PR DESCRIPTION
Changes:
- `Unlock All Suits` will no longer be displayed when all suits are unlocked
- Removed unnecessary `Upgrades:` title
- If all upgrades and suits are unlocked, display a message.
- Updated Changelog
- Removed unnecessary upgrades from `enum UnlockableUpgrade`